### PR TITLE
feat(client): implement local credential store

### DIFF
--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -17,6 +18,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tempfile",
  "tokio",
  "ureq",
  "uuid",
@@ -27,6 +29,18 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -966,6 +980,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,9 +1500,27 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1986,6 +2030,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3225,6 +3280,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4768,6 +4837,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -26,8 +26,12 @@ reqwest = { version = "0.12.28", default-features = false, features = [
     "rustls-tls",
     "stream",
 ] }
+rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "net", "process", "rt", "sync", "time"] }
 ureq = { version = "2.10", features = ["json"] }
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/apps/client/src-tauri/src/credential_store.rs
+++ b/apps/client/src-tauri/src/credential_store.rs
@@ -1,0 +1,540 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredCredential {
+    pub profile_id: String,
+    pub provider_id: String,
+    pub auth_type: String,
+    pub auth_data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredCustomProvider {
+    pub profile_id: String,
+    pub provider_id: String,
+    pub provider_name: String,
+    pub provider_config: String,
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+pub struct CredentialStore {
+    conn: Mutex<Connection>,
+}
+
+impl CredentialStore {
+    pub fn init(app_data_dir: PathBuf) -> Result<Self, String> {
+        fs::create_dir_all(&app_data_dir)
+            .map_err(|e| format!("failed to create app data dir: {e}"))?;
+
+        let db_path = app_data_dir.join("credentials.db");
+        let conn = Connection::open(&db_path)
+            .map_err(|e| format!("failed to open credentials db at {}: {e}", db_path.display()))?;
+
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS provider_credentials (
+                profile_id  TEXT NOT NULL,
+                provider_id TEXT NOT NULL,
+                auth_type   TEXT NOT NULL,
+                auth_data   TEXT NOT NULL,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (profile_id, provider_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS custom_providers (
+                profile_id      TEXT NOT NULL,
+                provider_id     TEXT NOT NULL,
+                provider_name   TEXT NOT NULL,
+                provider_config TEXT NOT NULL,
+                created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (profile_id, provider_id)
+            );
+            ",
+        )
+        .map_err(|e| format!("failed to initialise credential store schema: {e}"))?;
+
+        println!(
+            "[deck-credential-store] Initialised at {}",
+            db_path.display()
+        );
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    // -- internal helpers ---------------------------------------------------
+
+    fn execute(&self, sql: &str, params: &[&dyn rusqlite::types::ToSql]) -> Result<(), String> {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        conn.execute(sql, params)
+            .map_err(|e| format!("query failed: {e}"))?;
+        Ok(())
+    }
+
+    fn query_rows<T, F>(&self, sql: &str, profile_id: &str, map_row: F) -> Result<Vec<T>, String>
+    where
+        F: FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+    {
+        let conn = self.conn.lock().map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare(sql)
+            .map_err(|e| format!("prepare failed: {e}"))?;
+        let rows = stmt
+            .query_map(rusqlite::params![profile_id], map_row)
+            .map_err(|e| format!("query failed: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("row read failed: {e}"))
+    }
+
+    // -- credentials --------------------------------------------------------
+
+    pub fn save_credential(&self, cred: &StoredCredential) -> Result<(), String> {
+        self.execute(
+            "INSERT INTO provider_credentials (profile_id, provider_id, auth_type, auth_data, updated_at)
+             VALUES (?1, ?2, ?3, ?4, datetime('now'))
+             ON CONFLICT (profile_id, provider_id) DO UPDATE SET
+                auth_type  = excluded.auth_type,
+                auth_data  = excluded.auth_data,
+                updated_at = datetime('now')",
+            &[
+                &cred.profile_id as &dyn rusqlite::types::ToSql,
+                &cred.provider_id,
+                &cred.auth_type,
+                &cred.auth_data,
+            ],
+        )
+    }
+
+    pub fn list_credentials(&self, profile_id: &str) -> Result<Vec<StoredCredential>, String> {
+        self.query_rows(
+            "SELECT profile_id, provider_id, auth_type, auth_data
+             FROM provider_credentials WHERE profile_id = ?1",
+            profile_id,
+            |row| {
+                Ok(StoredCredential {
+                    profile_id: row.get(0)?,
+                    provider_id: row.get(1)?,
+                    auth_type: row.get(2)?,
+                    auth_data: row.get(3)?,
+                })
+            },
+        )
+    }
+
+    pub fn remove_credential(&self, profile_id: &str, provider_id: &str) -> Result<(), String> {
+        self.execute(
+            "DELETE FROM provider_credentials WHERE profile_id = ?1 AND provider_id = ?2",
+            &[
+                &profile_id as &dyn rusqlite::types::ToSql,
+                &provider_id,
+            ],
+        )
+    }
+
+    // -- custom providers ---------------------------------------------------
+
+    pub fn save_custom_provider(&self, provider: &StoredCustomProvider) -> Result<(), String> {
+        self.execute(
+            "INSERT INTO custom_providers (profile_id, provider_id, provider_name, provider_config, updated_at)
+             VALUES (?1, ?2, ?3, ?4, datetime('now'))
+             ON CONFLICT (profile_id, provider_id) DO UPDATE SET
+                provider_name   = excluded.provider_name,
+                provider_config = excluded.provider_config,
+                updated_at      = datetime('now')",
+            &[
+                &provider.profile_id as &dyn rusqlite::types::ToSql,
+                &provider.provider_id,
+                &provider.provider_name,
+                &provider.provider_config,
+            ],
+        )
+    }
+
+    pub fn list_custom_providers(
+        &self,
+        profile_id: &str,
+    ) -> Result<Vec<StoredCustomProvider>, String> {
+        self.query_rows(
+            "SELECT profile_id, provider_id, provider_name, provider_config
+             FROM custom_providers WHERE profile_id = ?1",
+            profile_id,
+            |row| {
+                Ok(StoredCustomProvider {
+                    profile_id: row.get(0)?,
+                    provider_id: row.get(1)?,
+                    provider_name: row.get(2)?,
+                    provider_config: row.get(3)?,
+                })
+            },
+        )
+    }
+
+    pub fn remove_custom_provider(
+        &self,
+        profile_id: &str,
+        provider_id: &str,
+    ) -> Result<(), String> {
+        self.execute(
+            "DELETE FROM custom_providers WHERE profile_id = ?1 AND provider_id = ?2",
+            &[
+                &profile_id as &dyn rusqlite::types::ToSql,
+                &provider_id,
+            ],
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+//
+// Input types use the same struct as the store types where possible.
+// For remove operations a minimal input with only the key fields is used.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveByProfileAndProviderInput {
+    pub profile_id: String,
+    pub provider_id: String,
+}
+
+#[tauri::command]
+pub fn save_credential(
+    state: tauri::State<'_, CredentialStore>,
+    input: StoredCredential,
+) -> Result<(), String> {
+    state.save_credential(&input)
+}
+
+#[tauri::command]
+pub fn list_credentials(
+    state: tauri::State<'_, CredentialStore>,
+    profile_id: String,
+) -> Result<Vec<StoredCredential>, String> {
+    state.list_credentials(&profile_id)
+}
+
+#[tauri::command]
+pub fn remove_credential(
+    state: tauri::State<'_, CredentialStore>,
+    input: RemoveByProfileAndProviderInput,
+) -> Result<(), String> {
+    state.remove_credential(&input.profile_id, &input.provider_id)
+}
+
+#[tauri::command]
+pub fn save_custom_provider(
+    state: tauri::State<'_, CredentialStore>,
+    input: StoredCustomProvider,
+) -> Result<(), String> {
+    state.save_custom_provider(&input)
+}
+
+#[tauri::command]
+pub fn list_custom_providers(
+    state: tauri::State<'_, CredentialStore>,
+    profile_id: String,
+) -> Result<Vec<StoredCustomProvider>, String> {
+    state.list_custom_providers(&profile_id)
+}
+
+#[tauri::command]
+pub fn remove_custom_provider(
+    state: tauri::State<'_, CredentialStore>,
+    input: RemoveByProfileAndProviderInput,
+) -> Result<(), String> {
+    state.remove_custom_provider(&input.profile_id, &input.provider_id)
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation helper
+// ---------------------------------------------------------------------------
+
+pub fn init_credential_store(app: &tauri::App) -> Result<CredentialStore, String> {
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("failed to resolve app data dir: {e}"))?;
+    CredentialStore::init(data_dir)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_store() -> (CredentialStore, TempDir) {
+        let dir = TempDir::new().expect("failed to create temp dir");
+        let store = CredentialStore::init(dir.path().to_path_buf()).expect("init failed");
+        (store, dir)
+    }
+
+    // -- credential CRUD ----------------------------------------------------
+
+    #[test]
+    fn save_and_list_credentials() {
+        let (store, _dir) = create_test_store();
+        let cred = StoredCredential {
+            profile_id: "local".into(),
+            provider_id: "openrouter".into(),
+            auth_type: "api".into(),
+            auth_data: r#"{"type":"api","key":"sk-test-123"}"#.into(),
+        };
+        store.save_credential(&cred).unwrap();
+
+        let creds = store.list_credentials("local").unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].provider_id, "openrouter");
+        assert_eq!(creds[0].auth_type, "api");
+        assert_eq!(creds[0].auth_data, cred.auth_data);
+    }
+
+    #[test]
+    fn save_credential_upserts_on_conflict() {
+        let (store, _dir) = create_test_store();
+        let cred1 = StoredCredential {
+            profile_id: "local".into(),
+            provider_id: "openrouter".into(),
+            auth_type: "api".into(),
+            auth_data: r#"{"type":"api","key":"old-key"}"#.into(),
+        };
+        store.save_credential(&cred1).unwrap();
+
+        let cred2 = StoredCredential {
+            auth_data: r#"{"type":"api","key":"new-key"}"#.into(),
+            ..cred1
+        };
+        store.save_credential(&cred2).unwrap();
+
+        let creds = store.list_credentials("local").unwrap();
+        assert_eq!(creds.len(), 1);
+        assert!(creds[0].auth_data.contains("new-key"));
+    }
+
+    #[test]
+    fn remove_credential_deletes_matching_row() {
+        let (store, _dir) = create_test_store();
+        store
+            .save_credential(&StoredCredential {
+                profile_id: "local".into(),
+                provider_id: "openrouter".into(),
+                auth_type: "api".into(),
+                auth_data: "{}".into(),
+            })
+            .unwrap();
+        store
+            .save_credential(&StoredCredential {
+                profile_id: "local".into(),
+                provider_id: "anthropic".into(),
+                auth_type: "api".into(),
+                auth_data: "{}".into(),
+            })
+            .unwrap();
+
+        store.remove_credential("local", "openrouter").unwrap();
+        let creds = store.list_credentials("local").unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].provider_id, "anthropic");
+    }
+
+    #[test]
+    fn remove_nonexistent_credential_is_noop() {
+        let (store, _dir) = create_test_store();
+        let result = store.remove_credential("local", "nonexistent");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn list_credentials_scoped_by_profile() {
+        let (store, _dir) = create_test_store();
+        store
+            .save_credential(&StoredCredential {
+                profile_id: "local".into(),
+                provider_id: "openrouter".into(),
+                auth_type: "api".into(),
+                auth_data: "{}".into(),
+            })
+            .unwrap();
+        store
+            .save_credential(&StoredCredential {
+                profile_id: "remote-1".into(),
+                provider_id: "anthropic".into(),
+                auth_type: "api".into(),
+                auth_data: "{}".into(),
+            })
+            .unwrap();
+
+        assert_eq!(store.list_credentials("local").unwrap().len(), 1);
+        assert_eq!(store.list_credentials("remote-1").unwrap().len(), 1);
+        assert_eq!(store.list_credentials("unknown").unwrap().len(), 0);
+    }
+
+    // -- custom provider CRUD -----------------------------------------------
+
+    #[test]
+    fn save_and_list_custom_providers() {
+        let (store, _dir) = create_test_store();
+        let cp = StoredCustomProvider {
+            profile_id: "local".into(),
+            provider_id: "my-provider".into(),
+            provider_name: "My Provider".into(),
+            provider_config: r#"{"npm":"@ai-sdk/openai-compatible"}"#.into(),
+        };
+        store.save_custom_provider(&cp).unwrap();
+
+        let providers = store.list_custom_providers("local").unwrap();
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].provider_id, "my-provider");
+        assert_eq!(providers[0].provider_name, "My Provider");
+    }
+
+    #[test]
+    fn save_custom_provider_upserts_on_conflict() {
+        let (store, _dir) = create_test_store();
+        let cp1 = StoredCustomProvider {
+            profile_id: "local".into(),
+            provider_id: "my-provider".into(),
+            provider_name: "Old Name".into(),
+            provider_config: "{}".into(),
+        };
+        store.save_custom_provider(&cp1).unwrap();
+
+        let cp2 = StoredCustomProvider {
+            provider_name: "New Name".into(),
+            ..cp1
+        };
+        store.save_custom_provider(&cp2).unwrap();
+
+        let providers = store.list_custom_providers("local").unwrap();
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].provider_name, "New Name");
+    }
+
+    #[test]
+    fn remove_custom_provider_deletes_matching_row() {
+        let (store, _dir) = create_test_store();
+        store
+            .save_custom_provider(&StoredCustomProvider {
+                profile_id: "local".into(),
+                provider_id: "p1".into(),
+                provider_name: "P1".into(),
+                provider_config: "{}".into(),
+            })
+            .unwrap();
+        store
+            .save_custom_provider(&StoredCustomProvider {
+                profile_id: "local".into(),
+                provider_id: "p2".into(),
+                provider_name: "P2".into(),
+                provider_config: "{}".into(),
+            })
+            .unwrap();
+
+        store.remove_custom_provider("local", "p1").unwrap();
+        let providers = store.list_custom_providers("local").unwrap();
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].provider_id, "p2");
+    }
+
+    #[test]
+    fn custom_providers_scoped_by_profile() {
+        let (store, _dir) = create_test_store();
+        store
+            .save_custom_provider(&StoredCustomProvider {
+                profile_id: "local".into(),
+                provider_id: "p1".into(),
+                provider_name: "P1".into(),
+                provider_config: "{}".into(),
+            })
+            .unwrap();
+        store
+            .save_custom_provider(&StoredCustomProvider {
+                profile_id: "remote-1".into(),
+                provider_id: "p2".into(),
+                provider_name: "P2".into(),
+                provider_config: "{}".into(),
+            })
+            .unwrap();
+
+        assert_eq!(store.list_custom_providers("local").unwrap().len(), 1);
+        assert_eq!(store.list_custom_providers("remote-1").unwrap().len(), 1);
+        assert_eq!(store.list_custom_providers("unknown").unwrap().len(), 0);
+    }
+
+    // -- cross-table independence -------------------------------------------
+
+    #[test]
+    fn credentials_and_custom_providers_are_independent() {
+        let (store, _dir) = create_test_store();
+        store
+            .save_credential(&StoredCredential {
+                profile_id: "local".into(),
+                provider_id: "shared-id".into(),
+                auth_type: "api".into(),
+                auth_data: "{}".into(),
+            })
+            .unwrap();
+        store
+            .save_custom_provider(&StoredCustomProvider {
+                profile_id: "local".into(),
+                provider_id: "shared-id".into(),
+                provider_name: "Shared".into(),
+                provider_config: "{}".into(),
+            })
+            .unwrap();
+
+        store.remove_credential("local", "shared-id").unwrap();
+        assert_eq!(store.list_credentials("local").unwrap().len(), 0);
+        assert_eq!(store.list_custom_providers("local").unwrap().len(), 1);
+    }
+
+    // -- init / schema ------------------------------------------------------
+
+    #[test]
+    fn init_creates_db_file() {
+        let dir = TempDir::new().unwrap();
+        let _store = CredentialStore::init(dir.path().to_path_buf()).unwrap();
+        assert!(dir.path().join("credentials.db").exists());
+    }
+
+    #[test]
+    fn init_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_path_buf();
+        let store1 = CredentialStore::init(path.clone()).unwrap();
+        store1
+            .save_credential(&StoredCredential {
+                profile_id: "local".into(),
+                provider_id: "x".into(),
+                auth_type: "api".into(),
+                auth_data: "{}".into(),
+            })
+            .unwrap();
+        drop(store1);
+
+        let store2 = CredentialStore::init(path).unwrap();
+        let creds = store2.list_credentials("local").unwrap();
+        assert_eq!(creds.len(), 1);
+    }
+}

--- a/apps/client/src/components/config/custom-provider-dialog.tsx
+++ b/apps/client/src/components/config/custom-provider-dialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dialog';
 import { useAddCustomProvider } from '@/hooks/use-config';
 import { t } from '@/i18n';
+import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -197,6 +198,13 @@ export function CustomProviderDialog({
                 id="provider-id"
                 placeholder={t('custom_provider.placeholder_id')}
                 value={providerId}
+                className={cn(
+                  providerId ? 'text-foreground' : 'text-muted-foreground',
+                )}
+                autoComplete="off"
+                spellCheck={false}
+                autoCapitalize="none"
+                autoCorrect="off"
                 onChange={(e) => setProviderId(e.target.value)}
               />
               <p className="text-[11px] text-muted-foreground">
@@ -211,6 +219,9 @@ export function CustomProviderDialog({
                 id="display-name"
                 placeholder={t('custom_provider.placeholder_name')}
                 value={displayName}
+                className={cn(
+                  displayName ? 'text-foreground' : 'text-muted-foreground',
+                )}
                 onChange={(e) => setDisplayName(e.target.value)}
               />
             </div>
@@ -223,6 +234,9 @@ export function CustomProviderDialog({
                 placeholder={t('custom_provider.placeholder_url')}
                 value={baseURL}
                 onChange={(e) => setBaseURL(e.target.value)}
+                className={cn(
+                  baseURL ? 'text-foreground' : 'text-muted-foreground',
+                )}
               />
             </div>
 
@@ -235,6 +249,9 @@ export function CustomProviderDialog({
                 placeholder={t('custom_provider.api_key')}
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
+                className={cn(
+                  apiKey ? 'text-foreground' : 'text-muted-foreground',
+                )}
               />
               <p className="text-[11px] text-muted-foreground">
                 {t('custom_provider.api_key_hint')}
@@ -252,13 +269,19 @@ export function CustomProviderDialog({
                     placeholder="model-id"
                     value={model.id}
                     onChange={(e) => updateModel(index, 'id', e.target.value)}
-                    className="h-8 text-xs flex-1"
+                    className={cn(
+                      "h-8 text-xs flex-1",
+                      model.id ? 'text-foreground' : 'text-muted-foreground',
+                    )}
                   />
                   <Input
                     placeholder="Display Name"
                     value={model.name}
                     onChange={(e) => updateModel(index, 'name', e.target.value)}
-                    className="h-8 text-xs flex-1"
+                    className={cn(
+                      "h-8 text-xs flex-1",
+                      model.name ? 'text-foreground' : 'text-muted-foreground',
+                    )}
                   />
                   <Button
                     variant="ghost"
@@ -293,7 +316,10 @@ export function CustomProviderDialog({
                     placeholder="Header-Name"
                     value={header.key}
                     onChange={(e) => updateHeader(index, 'key', e.target.value)}
-                    className="h-8 text-xs flex-1"
+                    className={cn(
+                      "h-8 text-xs flex-1",
+                      header.key ? 'text-foreground' : 'text-muted-foreground',
+                    )}
                   />
                   <Input
                     placeholder="value"
@@ -301,7 +327,10 @@ export function CustomProviderDialog({
                     onChange={(e) =>
                       updateHeader(index, 'value', e.target.value)
                     }
-                    className="h-8 text-xs flex-1"
+                    className={cn(
+                      "h-8 text-xs flex-1",
+                      header.value ? 'text-foreground' : 'text-muted-foreground',
+                    )}
                   />
                   <Button
                     variant="ghost"

--- a/apps/client/src/components/config/model-selector.tsx
+++ b/apps/client/src/components/config/model-selector.tsx
@@ -56,6 +56,7 @@ import { t } from '@/i18n';
 function useValidateStoredModel(models: FlatModel[]) {
   const recentModels = useModelPreferencesStore((s) => s.recent);
   const selectModel = useModelPreferencesStore((s) => s.selectModel);
+  const reset = useModelPreferencesStore((s) => s.reset);
 
   useEffect(() => {
     // Only validate after models have loaded
@@ -77,9 +78,16 @@ function useValidateStoredModel(models: FlatModel[]) {
           `[ModelSelector] Stored model "${activeKey}" no longer available. Falling back to "${fallback.key}".`,
         );
         selectModel(fallback.providerID, fallback.model.id);
+      } else {
+        // No connected providers at all — clear stale selection to avoid
+        // sending requests to an unauthenticated provider.
+        console.warn(
+          `[ModelSelector] No connected providers found. Clearing stale model selection.`,
+        );
+        reset();
       }
     }
-  }, [models, recentModels, selectModel]);
+  }, [models, recentModels, selectModel, reset]);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/src/components/config/provider-auth-dialog.tsx
+++ b/apps/client/src/components/config/provider-auth-dialog.tsx
@@ -22,6 +22,7 @@ import { useSetAuth, useProviderAuthMethods } from '@/hooks/use-config';
 import { useOpenCodeClient } from '@/hooks/use-opencode-client';
 import { unwrap } from '@/lib/opencode';
 import { t } from '@/i18n';
+import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -159,6 +160,9 @@ export function ProviderAuthDialog({
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') handleSaveApiKey();
                 }}
+                className={cn(
+                  apiKey ? 'text-foreground' : 'text-muted-foreground',
+                )}
               />
             </div>
           )}

--- a/apps/client/src/components/config/provider-list.tsx
+++ b/apps/client/src/components/config/provider-list.tsx
@@ -246,8 +246,16 @@ export function ProviderList({
             <Input
               placeholder={t('provider.search')}
               value={search}
+              autoComplete="off"
+              spellCheck={false}
+              autoCapitalize="none"
+              autoCorrect="off"
               onChange={(e) => setSearch(e.target.value)}
-              className="h-7 pl-7 text-xs"
+              className={cn(
+                'h-7 pl-7 text-xs',
+                'placeholder:text-current',
+                search ? 'text-foreground' : 'text-muted-foreground',
+              )}
             />
           </div>
           <Button

--- a/apps/client/src/components/config/settings-sheet.tsx
+++ b/apps/client/src/components/config/settings-sheet.tsx
@@ -227,8 +227,16 @@ function ModelTogglesSection() {
         <Input
           placeholder={t('config.search_models')}
           value={search}
+          autoComplete="off"
+          spellCheck={false}
+          autoCapitalize="none"
+          autoCorrect="off"
           onChange={(e) => setSearch(e.target.value)}
-          className="h-7 pl-7 text-xs"
+          className={cn(
+            'h-7 pl-7 text-xs',
+            'placeholder:text-current',
+            search ? 'text-foreground' : 'text-muted-foreground',
+          )}
         />
       </div>
       <div className="max-h-[280px] overflow-y-auto rounded-md border p-1">
@@ -382,9 +390,15 @@ export function SettingsSheet() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="manual">{t('config.share_manual')}</SelectItem>
-                        <SelectItem value="auto">{t('config.share_auto')}</SelectItem>
-                        <SelectItem value="disabled">{t('config.share_disabled')}</SelectItem>
+                        <SelectItem value="manual">
+                          {t('config.share_manual')}
+                        </SelectItem>
+                        <SelectItem value="auto">
+                          {t('config.share_auto')}
+                        </SelectItem>
+                        <SelectItem value="disabled">
+                          {t('config.share_disabled')}
+                        </SelectItem>
                       </SelectContent>
                     </Select>
                   </FieldRow>

--- a/apps/client/src/components/project/project-picker-dialog.tsx
+++ b/apps/client/src/components/project/project-picker-dialog.tsx
@@ -194,7 +194,10 @@ export function ProjectPickerDialog() {
               value={search}
               onChange={(e) => handleSearchChange(e.target.value)}
               onKeyDown={handleKeyDown}
-              className="pl-8"
+              className={cn(
+                'pl-8',
+                search ? 'text-foreground' : 'text-muted-foreground',
+              )}
               autoFocus
               spellCheck={false}
               autoCorrect="off"

--- a/apps/client/src/lib/credential-store.ts
+++ b/apps/client/src/lib/credential-store.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Thin wrappers around the Tauri credential-store commands.
+ * All functions are no-ops when running outside Tauri (browser dev mode).
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+import { isTauriRuntime } from './utils';
+
+// ---------------------------------------------------------------------------
+// Types (mirror Rust serde output — camelCase)
+// ---------------------------------------------------------------------------
+
+export interface StoredCredential {
+  profileId: string;
+  providerId: string;
+  authType: string;
+  authData: string;
+}
+
+export interface StoredCustomProvider {
+  profileId: string;
+  providerId: string;
+  providerName: string;
+  providerConfig: string;
+}
+
+// ---------------------------------------------------------------------------
+// Credential operations
+// ---------------------------------------------------------------------------
+
+export async function saveCredential(
+  profileId: string,
+  providerId: string,
+  authType: string,
+  authData: string,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  await invoke('save_credential', {
+    input: { profileId, providerId, authType, authData },
+  });
+}
+
+export async function listCredentials(
+  profileId: string,
+): Promise<StoredCredential[]> {
+  if (!isTauriRuntime()) return [];
+  return invoke('list_credentials', { profileId });
+}
+
+export async function removeCredential(
+  profileId: string,
+  providerId: string,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  await invoke('remove_credential', {
+    input: { profileId, providerId },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Custom provider operations
+// ---------------------------------------------------------------------------
+
+export async function saveCustomProvider(
+  profileId: string,
+  providerId: string,
+  providerName: string,
+  providerConfig: string,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  await invoke('save_custom_provider', {
+    input: { profileId, providerId, providerName, providerConfig },
+  });
+}
+
+export async function listCustomProviders(
+  profileId: string,
+): Promise<StoredCustomProvider[]> {
+  if (!isTauriRuntime()) return [];
+  return invoke('list_custom_providers', { profileId });
+}
+
+export async function removeCustomProvider(
+  profileId: string,
+  providerId: string,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  await invoke('remove_custom_provider', {
+    input: { profileId, providerId },
+  });
+}


### PR DESCRIPTION
This PR introduces a local credential store to persist provider credentials across application restarts.

It uses a local SQLite database on the Tauri backend to save credentials when a user authenticates. When the application starts, these credentials are automatically restored, preventing users from having to re-authenticate after every session.