### PR TITLE
feat(client): Implement Update Notifications and Fix IME Input

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -44,7 +44,6 @@
     "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
-    "@tauri-apps/plugin-updater": "^2.10.0",
     "axios": "^1.13.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/client/src-tauri/tauri.conf.json
+++ b/apps/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "deck",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "identifier": "com.cofy-x.deck",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/client/src/components/config/about-section.tsx
+++ b/apps/client/src/components/config/about-section.tsx
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { RefreshCw, ExternalLink } from 'lucide-react';
+
+import { t } from '@/i18n';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useUpdateCheck } from '@/hooks/use-update-check';
+
+export function AboutSection() {
+  const {
+    currentVersion,
+    latestVersion,
+    hasUpdate,
+    isChecking,
+    refetch,
+    openReleasePage,
+    releaseUrl,
+  } = useUpdateCheck();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold">{t('config.about')}</h3>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-0.5">
+          <Label className="text-sm">{t('update.current_version')}</Label>
+          <span className="text-xs text-muted-foreground">
+            v{currentVersion ?? '...'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasUpdate && latestVersion && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-xs"
+              onClick={() => openReleasePage(releaseUrl ?? undefined)}
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t('update.new_version_badge').replace(
+                '{version}',
+                latestVersion,
+              )}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
+            disabled={isChecking}
+            onClick={() => refetch()}
+          >
+            <RefreshCw
+              className={cn('h-3 w-3', isChecking && 'animate-spin')}
+            />
+            {isChecking ? t('update.checking') : t('update.check')}
+          </Button>
+        </div>
+      </div>
+      {!hasUpdate && currentVersion && !isChecking && (
+        <p className="text-xs text-muted-foreground">
+          {t('update.up_to_date')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/config/settings-sheet.tsx
+++ b/apps/client/src/components/config/settings-sheet.tsx
@@ -40,6 +40,7 @@ import { useModelPreferencesStore } from '@/stores/model-preferences-store';
 import { useDebugStore } from '@/stores/debug-store';
 import { useConfig, useUpdateConfig, useProviders } from '@/hooks/use-config';
 import type { FlatModel } from '@/hooks/use-config';
+import { AboutSection } from '@/components/config/about-section';
 
 // ---------------------------------------------------------------------------
 // Section wrapper
@@ -454,6 +455,11 @@ export function SettingsSheet() {
                     />
                   </FieldRow>
                 </SettingsSection>
+
+                <Separator />
+
+                {/* --- About --- */}
+                <AboutSection />
               </>
             )}
           </div>

--- a/apps/client/src/components/layout/cockpit-layout.tsx
+++ b/apps/client/src/components/layout/cockpit-layout.tsx
@@ -61,6 +61,7 @@ import {
 } from '@/hooks/use-sandbox';
 import { cn } from '@/lib/utils';
 import { t } from '@/i18n';
+import { useUpdateCheck } from '@/hooks/use-update-check';
 
 const SANDBOX_HOME_PREFIX = '/home/deck/';
 
@@ -103,6 +104,8 @@ export function CockpitLayout() {
   const { profile, isRemote, isLocal } = useActiveConnection();
   const { active: pathCopied, trigger: triggerPathCopied } =
     useTransientFlag(1200);
+
+  useUpdateCheck();
   const previousSwitchNonceRef = useRef<number>(switchNonce);
   const rightPanelRef = useRef<PanelImperativeHandle | null>(null);
 

--- a/apps/client/src/hooks/use-ime-enter-guard.ts
+++ b/apps/client/src/hooks/use-ime-enter-guard.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useCallback, useEffect, useRef } from 'react';
+import type { KeyboardEvent } from 'react';
+
+/**
+ * Guard keyboard shortcuts while IME composition is active.
+ * Includes a one-tick buffer after compositionend to avoid accidental submit.
+ */
+export function useImeEnterGuard() {
+  const isComposingRef = useRef(false);
+  const compositionJustEndedRef = useRef(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearResetTimer = useCallback(() => {
+    if (resetTimerRef.current) {
+      clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+  }, []);
+
+  const onCompositionStart = useCallback(() => {
+    clearResetTimer();
+    isComposingRef.current = true;
+    compositionJustEndedRef.current = false;
+  }, [clearResetTimer]);
+
+  const onCompositionEnd = useCallback(() => {
+    isComposingRef.current = false;
+    compositionJustEndedRef.current = true;
+    clearResetTimer();
+    resetTimerRef.current = setTimeout(() => {
+      compositionJustEndedRef.current = false;
+      resetTimerRef.current = null;
+    }, 0);
+  }, [clearResetTimer]);
+
+  useEffect(() => () => clearResetTimer(), [clearResetTimer]);
+
+  const shouldBlockKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLElement>) =>
+      e.nativeEvent.isComposing ||
+      isComposingRef.current ||
+      compositionJustEndedRef.current ||
+      e.key === 'Process',
+    [],
+  );
+
+  return { onCompositionStart, onCompositionEnd, shouldBlockKeyDown };
+}

--- a/apps/client/src/hooks/use-update-check.ts
+++ b/apps/client/src/hooks/use-update-check.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * TanStack Query hook that periodically checks GitHub Releases for a newer
+ * version and surfaces a Sonner toast the first time a new version is detected.
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { openUrl } from '@tauri-apps/plugin-opener';
+
+import { t } from '@/i18n';
+import { UPDATE_DISMISSED_KEY } from '@/lib/constants';
+import { isTauriRuntime } from '@/lib/utils';
+import {
+  checkForUpdates,
+  GITHUB_RELEASES_PAGE,
+  type UpdateCheckResult,
+} from '@/lib/update-check';
+
+// ---------------------------------------------------------------------------
+// Query key
+// ---------------------------------------------------------------------------
+
+const UPDATE_CHECK_KEY = ['app', 'updateCheck'] as const;
+
+// ---------------------------------------------------------------------------
+// Dismiss helpers (localStorage)
+// ---------------------------------------------------------------------------
+
+function getDismissedVersion(): string | null {
+  try {
+    return window.localStorage.getItem(UPDATE_DISMISSED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setDismissedVersion(version: string) {
+  try {
+    window.localStorage.setItem(UPDATE_DISMISSED_KEY, version);
+  } catch {
+    /* noop */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const FOUR_HOURS = 4 * 60 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+
+export function useUpdateCheck() {
+  const queryClient = useQueryClient();
+  const toastShownForRef = useRef<string | null>(null);
+
+  const query = useQuery<UpdateCheckResult>({
+    queryKey: UPDATE_CHECK_KEY,
+    queryFn: checkForUpdates,
+    staleTime: ONE_HOUR,
+    refetchInterval: FOUR_HOURS,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  const { data } = query;
+
+  const openReleasePage = useCallback((url?: string) => {
+    const target = url || GITHUB_RELEASES_PAGE;
+    if (isTauriRuntime()) {
+      openUrl(target).catch(() => window.open(target, '_blank'));
+    } else {
+      window.open(target, '_blank');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!data?.hasUpdate || !data.latestRelease) return;
+
+    const latestVer = data.latestRelease.version;
+
+    if (getDismissedVersion() === latestVer) return;
+    if (toastShownForRef.current === latestVer) return;
+
+    toastShownForRef.current = latestVer;
+
+    const description = t('update.available_description').replace(
+      '{version}',
+      latestVer,
+    );
+
+    toast(t('update.available_title'), {
+      description,
+      duration: 15_000,
+      action: {
+        label: t('update.download'),
+        onClick: () => openReleasePage(data.latestRelease!.htmlUrl),
+      },
+      cancel: {
+        label: t('update.dismiss'),
+        onClick: () => setDismissedVersion(latestVer),
+      },
+    });
+  }, [data, openReleasePage]);
+
+  const refetch = useCallback(() => queryClient.invalidateQueries({ queryKey: UPDATE_CHECK_KEY }), [queryClient]);
+
+  return {
+    currentVersion: data?.currentVersion ?? null,
+    latestVersion: data?.latestRelease?.version ?? null,
+    releaseUrl: data?.latestRelease?.htmlUrl ?? null,
+    hasUpdate: data?.hasUpdate ?? false,
+    isChecking: query.isFetching,
+    refetch,
+    openReleasePage,
+  };
+}

--- a/apps/client/src/i18n/locales/en.ts
+++ b/apps/client/src/i18n/locales/en.ts
@@ -456,6 +456,26 @@ export const en: Record<string, string> = {
   'time.days_ago': '{n}d ago',
 
   // ---------------------------------------------------------------------------
+  // Update check
+  // ---------------------------------------------------------------------------
+  'update.available_title': 'Update Available',
+  'update.available_description':
+    'New version v{version} is ready to download.',
+  'update.download': 'Download',
+  'update.dismiss': 'Dismiss',
+  'update.check': 'Check for updates',
+  'update.checking': 'Checking...',
+  'update.up_to_date': 'You are on the latest version.',
+  'update.check_failed': 'Failed to check for updates.',
+  'update.current_version': 'Version',
+  'update.new_version_badge': 'v{version} available',
+
+  // ---------------------------------------------------------------------------
+  // About section (settings)
+  // ---------------------------------------------------------------------------
+  'config.about': 'About',
+
+  // ---------------------------------------------------------------------------
   // Connection store
   // ---------------------------------------------------------------------------
   'store.local_sandbox': 'Local Sandbox',

--- a/apps/client/src/i18n/locales/zh.ts
+++ b/apps/client/src/i18n/locales/zh.ts
@@ -437,6 +437,26 @@ export const zh: Record<string, string> = {
   'time.days_ago': '{n} 天前',
 
   // ---------------------------------------------------------------------------
+  // Update check
+  // ---------------------------------------------------------------------------
+  'update.available_title': '发现新版本',
+  'update.available_description':
+    '新版本 v{version} 已发布，可前往下载。',
+  'update.download': '下载',
+  'update.dismiss': '忽略',
+  'update.check': '检查更新',
+  'update.checking': '检查中...',
+  'update.up_to_date': '当前已是最新版本。',
+  'update.check_failed': '检查更新失败。',
+  'update.current_version': '版本',
+  'update.new_version_badge': 'v{version} 可更新',
+
+  // ---------------------------------------------------------------------------
+  // About section (settings)
+  // ---------------------------------------------------------------------------
+  'config.about': '关于',
+
+  // ---------------------------------------------------------------------------
   // Connection store
   // ---------------------------------------------------------------------------
   'store.local_sandbox': '本地沙盒',

--- a/apps/client/src/lib/constants.ts
+++ b/apps/client/src/lib/constants.ts
@@ -45,6 +45,8 @@ export const DEFAULT_IMAGE = 'deck/desktop-sandbox-ai:latest';
 
 export const LANGUAGE_PREF_KEY = 'deck.language';
 
+export const UPDATE_DISMISSED_KEY = 'deck.update.dismissed';
+
 // ---------------------------------------------------------------------------
 // Display configuration
 // ---------------------------------------------------------------------------

--- a/apps/client/src/lib/update-check.ts
+++ b/apps/client/src/lib/update-check.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Lightweight update checker that queries GitHub Releases API
+ * and compares the latest published version against the running app version.
+ */
+
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import { getVersion } from '@tauri-apps/api/app';
+
+import { isTauriRuntime } from './utils';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const GITHUB_RELEASES_API =
+  'https://api.github.com/repos/cofy-x/deck/releases?per_page=1';
+
+export const GITHUB_RELEASES_PAGE =
+  'https://github.com/cofy-x/deck/releases';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReleaseInfo {
+  version: string;
+  tagName: string;
+  htmlUrl: string;
+  body: string;
+  publishedAt: string;
+  prerelease: boolean;
+}
+
+export interface UpdateCheckResult {
+  currentVersion: string;
+  latestRelease: ReleaseInfo | null;
+  hasUpdate: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Semver comparison (supports pre-release suffixes)
+// ---------------------------------------------------------------------------
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+function parseVersion(raw: string): ParsedVersion {
+  const cleaned = raw.replace(/^v/, '');
+  const [coreStr, ...preParts] = cleaned.split('-');
+  const parts = (coreStr ?? '').split('.').map(Number);
+  const prerelease = preParts.length > 0 ? preParts.join('-').split('.') : [];
+
+  return {
+    major: parts[0] ?? 0,
+    minor: parts[1] ?? 0,
+    patch: parts[2] ?? 0,
+    prerelease,
+  };
+}
+
+/**
+ * Compare two version strings. Returns:
+ *  -1 if a < b
+ *   0 if a == b
+ *   1 if a > b
+ *
+ * Pre-release versions are lower than the same release version:
+ *   0.0.1-alpha.1 < 0.0.1-alpha.2 < 0.0.1-beta.1 < 0.0.1
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
+
+  for (const field of ['major', 'minor', 'patch'] as const) {
+    if (va[field] < vb[field]) return -1;
+    if (va[field] > vb[field]) return 1;
+  }
+
+  if (va.prerelease.length === 0 && vb.prerelease.length === 0) return 0;
+  if (va.prerelease.length === 0) return 1;
+  if (vb.prerelease.length === 0) return -1;
+
+  const len = Math.max(va.prerelease.length, vb.prerelease.length);
+  for (let i = 0; i < len; i++) {
+    const pa = va.prerelease[i];
+    const pb = vb.prerelease[i];
+    if (pa === undefined) return -1;
+    if (pb === undefined) return 1;
+
+    const na = Number(pa);
+    const nb = Number(pb);
+    const aIsNum = !isNaN(na);
+    const bIsNum = !isNaN(nb);
+
+    if (aIsNum && bIsNum) {
+      if (na < nb) return -1;
+      if (na > nb) return 1;
+    } else {
+      if (pa < pb) return -1;
+      if (pa > pb) return 1;
+    }
+  }
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+async function fetchGitHubReleases(): Promise<ReleaseInfo | null> {
+  const doFetch = isTauriRuntime() ? tauriFetch : globalThis.fetch;
+
+  const resp = await doFetch(GITHUB_RELEASES_API, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'deck-desktop-client',
+    },
+  });
+
+  if (!resp.ok) return null;
+
+  const releases: Array<{
+    tag_name: string;
+    html_url: string;
+    body: string | null;
+    published_at: string;
+    prerelease: boolean;
+    draft: boolean;
+  }> = await resp.json();
+
+  const release = releases.find((r) => !r.draft);
+  if (!release) return null;
+
+  return {
+    version: release.tag_name.replace(/^v/, ''),
+    tagName: release.tag_name,
+    htmlUrl: release.html_url,
+    body: release.body ?? '',
+    publishedAt: release.published_at,
+    prerelease: release.prerelease,
+  };
+}
+
+async function getCurrentVersion(): Promise<string> {
+  if (isTauriRuntime()) {
+    return getVersion();
+  }
+  return '0.0.0-dev';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function checkForUpdates(): Promise<UpdateCheckResult> {
+  const [currentVersion, latestRelease] = await Promise.all([
+    getCurrentVersion(),
+    fetchGitHubReleases(),
+  ]);
+
+  const hasUpdate =
+    latestRelease !== null &&
+    compareVersions(currentVersion, latestRelease.version) === -1;
+
+  return { currentVersion, latestRelease, hasUpdate };
+}

--- a/docs/design/client-update-check.md
+++ b/docs/design/client-update-check.md
@@ -1,0 +1,112 @@
+# Client Update Check Design (apps/client)
+
+This document describes the update notification feature in the Deck desktop
+client and outlines the upgrade path to in-app auto-update.
+
+## Scope
+
+- Check for new releases via the GitHub Releases API.
+- Notify users when a newer version is available.
+- Provide a one-click path to the download page.
+
+Primary implementation files:
+
+- `apps/client/src/lib/update-check.ts` — GitHub API fetch, semver comparison
+- `apps/client/src/hooks/use-update-check.ts` — TanStack Query hook, toast trigger
+- `apps/client/src/components/config/settings-sheet.tsx` — About section in Settings
+- `apps/client/src/components/layout/cockpit-layout.tsx` — Hook mount point
+- `apps/client/src/lib/constants.ts` — `UPDATE_DISMISSED_KEY`
+- `apps/client/src/i18n/locales/en.ts` / `zh.ts` — i18n strings
+
+## Current Approach (v0.0.x — alpha)
+
+### Why frontend-only, not Rust-side
+
+The update check is a lightweight operation (HTTP GET + string comparison +
+UI notification) that fits naturally in the frontend layer. No Rust-side logic
+is needed because:
+
+- No file-system writes or process replacement are involved.
+- The Tauri webview stays alive while the window exists, so JS timers work
+  fine for periodic polling.
+- Moving logic to Rust would add unnecessary IPC bridging complexity.
+
+### Why manual download, not in-app auto-update
+
+The Tauri updater plugin (`tauri-plugin-updater`) requires:
+
+1. **Code-signed builds** — the CI currently produces unsigned DMGs.
+2. **Update manifests** (`latest.json`) generated and hosted alongside
+   release assets.
+3. **Rust-side plugin registration** and `tauri.conf.json` updater config.
+
+None of these prerequisites are in place yet. A simple "check and redirect"
+pattern is sufficient for the alpha stage where release frequency is low and
+the user base is small.
+
+### How it works
+
+1. On app mount, `useUpdateCheck()` fires a TanStack Query that calls the
+   GitHub Releases API: `GET /repos/cofy-x/deck/releases?per_page=1`.
+2. The response is compared against the running app version obtained from
+   `getVersion()` (`@tauri-apps/api/app`, reads the version embedded at
+   build time from `tauri.conf.json`).
+3. If a newer version is found and the user has not dismissed it, a Sonner
+   toast is shown with **Download** (opens release page in system browser)
+   and **Dismiss** (saves version to `localStorage` to suppress future
+   toasts for that version) actions.
+4. The query re-runs every 4 hours (`refetchInterval`) with a 1-hour stale
+   window.
+5. The Settings sheet includes an **About** section showing the current
+   version, a manual "Check for updates" button, and (when available) a
+   badge linking to the new release.
+
+### Version comparison
+
+Custom semver comparison supporting pre-release suffixes:
+
+```
+0.0.1-alpha.1 < 0.0.1-alpha.2 < 0.0.1-beta.1 < 0.0.1
+```
+
+The CI release workflow overrides `tauri.conf.json` version at build time,
+so production builds always carry the correct release version.
+
+## Future: In-App Auto-Update
+
+When the project reaches beta/stable and the following prerequisites are met,
+the update mechanism should be upgraded to use `tauri-plugin-updater` for
+seamless in-app updates:
+
+### Prerequisites
+
+- [ ] Apple Developer code signing configured in CI.
+- [ ] CI generates Tauri update manifests (`latest.json`) alongside DMG
+      assets in the GitHub release.
+- [ ] Windows builds added (requires Authenticode signing for updater).
+- [ ] `tauri-plugin-updater` added to `Cargo.toml` and registered in
+      `lib.rs`.
+- [ ] `tauri.conf.json` updater section configured with the endpoint URL.
+
+### Migration steps
+
+1. Add `tauri-plugin-updater` to `apps/client/src-tauri/Cargo.toml`.
+2. Register the plugin in `apps/client/src-tauri/src/lib.rs`.
+3. Add updater configuration to `apps/client/src-tauri/tauri.conf.json`.
+4. Update `apps/client/src-tauri/capabilities/default.json` with updater
+   permissions.
+5. Update CI workflow (`.github/workflows/client-release.yml`) to:
+   - Sign builds with Apple Developer certificate.
+   - Generate and upload `latest.json` manifest.
+6. Replace the frontend GitHub API check with the Tauri updater JS API
+   (`@tauri-apps/plugin-updater`, already removed from `package.json` —
+   re-add when ready).
+7. Keep the Settings About section but wire it to the native updater
+   progress instead of a browser redirect.
+
+### Cleanup on migration
+
+- Remove `apps/client/src/lib/update-check.ts` (GitHub API fetch logic).
+- Remove `UPDATE_DISMISSED_KEY` from `constants.ts` (native updater handles
+  this).
+- Simplify `use-update-check.ts` to wrap the Tauri updater API.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,9 +246,6 @@ importers:
       '@tauri-apps/plugin-shell':
         specifier: ^2.3.5
         version: 2.3.5
-      '@tauri-apps/plugin-updater':
-        specifier: ^2.10.0
-        version: 2.10.0
       axios:
         specifier: ^1.13.2
         version: 1.13.4
@@ -3296,9 +3293,6 @@ packages:
 
   '@tauri-apps/plugin-shell@2.3.5':
     resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
-
-  '@tauri-apps/plugin-updater@2.10.0':
-    resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -9987,10 +9981,6 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-shell@2.3.5':
-    dependencies:
-      '@tauri-apps/api': 2.10.1
-
-  '@tauri-apps/plugin-updater@2.10.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 


### PR DESCRIPTION
## Summary

This PR enhances the `client` application by introducing a manual update notification system and fixing a critical bug in the chat input related to IME (Input Method Editor) handling.

## Changes

### ✨ Features

- **Update Notification System**:
    - A new hook `useUpdateCheck` periodically checks the GitHub Releases API for new versions.
    - When a new version is detected, a toast notification is displayed, allowing the user to download it or dismiss the notification.
    - An "About" section has been added to the Settings panel, showing the current app version and providing a manual "Check for Updates" button.
    - A detailed design document (`docs/design/client-update-check.md`) has been added to explain the rationale behind this manual approach and outline the future migration path to full in-app auto-updates.

### 🐛 Bug Fixes

- **Chat Input IME Guard**:
    - Implemented a `useImeEnterGuard` hook to correctly handle the `Enter` key during IME composition. This prevents the chat message from being sent accidentally while the user is typing in languages like Chinese, Japanese, or Korean.

###  housekeeping

- **Dependency Cleanup**: Removed the unused `@tauri-apps/plugin-updater` package, as the new implementation provides a temporary, more suitable solution for the current alpha stage.
- **Version Correction**: Corrected the app version in `tauri.conf.json` from `0.1.0` to `0.0.1`.

## How to Test

1.  Run the `client` application.
2.  Open the settings panel to view the new "About" section. Click "Check for updates".
3.  Go to the chat input. Switch to a Pinyin/Japanese/Korean keyboard.
4.  Type some characters (e.g., "nihao"). While the IME selection window is open, press Enter.
5.  **Expected:** The text should be confirmed in the input box, but the message should NOT be sent.
6.  Press Enter again.
7.  **Expected:** The message should now be sent.