### PR TITLE
ci: enable auto-trigger for client-build and docker-desktop-images workflows

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -2,6 +2,24 @@ name: Client Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apps/client/**'
+      - 'packages/client-daemon-*/**'
+      - 'packages/core-ts/**'
+      - 'pnpm-lock.yaml'
+      - '.nvmrc'
+      - '.github/workflows/client-build.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/client/**'
+      - 'packages/client-daemon-*/**'
+      - 'packages/core-ts/**'
+      - 'pnpm-lock.yaml'
+      - '.nvmrc'
+      - '.github/workflows/client-build.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/docker-desktop-images.yml
+++ b/.github/workflows/docker-desktop-images.yml
@@ -2,6 +2,17 @@ name: Docker Desktop Images
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/desktop/**'
+      - 'docker/plugins/computer-use/**'
+      - 'packages/daemon/**'
+      - 'apps/cli/**'
+      - 'go.work'
+      - 'go.work.sum'
+      - '.github/workflows/docker-desktop-images.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Enable automatic triggering for `client-build.yml` on PR and push to main
- Enable automatic triggering for `docker-desktop-images.yml` on push to main
- Add path filters to ensure workflows only run when relevant files change

## Changes

### `client-build.yml`
- Add `pull_request` trigger with path filters for client app, daemon, and core-ts changes
- Add `push` trigger for main branch with same path filters
- Ensures build validation happens before merge

### `docker-desktop-images.yml`
- Add `push` trigger for main branch with path filters for desktop docker, daemon, and cli changes
- Automatically publishes updated images when changes land on main

## Test Plan

- [x] Verify workflows trigger correctly on relevant file changes
- [x] Verify workflows do not trigger on unrelated file changes
- [x] Verify manual trigger still works via workflow_dispatch


Made with [Cursor](https://cursor.com)